### PR TITLE
[REM] .gitmodules: Remove sh-tools from dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,6 @@
 	path = plecamer
 	url = git@git.vauxoo.com:Vauxoo/plecamer.git
 	branch = 13.0
-[submodule "sh-tools"]
-	path = sh-tools
-	url = git@git.vauxoo.com:Vauxoo/sh-tools.git
-	branch = 13.0
 [submodule "account_reconcile_partial"]
 	path = account_reconcile_partial
 	url = git@git.vauxoo.com:vauxoo/account_reconcile_partial.git


### PR DESCRIPTION
As this project doesn't use the costarrican localization and cause
conflicts.